### PR TITLE
Fix green in example becoming dimmer after 0.14 update

### DIFF
--- a/examples/skin_mesh.rs
+++ b/examples/skin_mesh.rs
@@ -1,4 +1,4 @@
-use bevy::{prelude::*, window::WindowResolution, color::palettes::css};
+use bevy::{color::palettes::css, prelude::*, window::WindowResolution};
 use bevy_mod_inverse_kinematics::*;
 
 #[derive(Component)]
@@ -114,7 +114,7 @@ fn setup_ik(
                 transform: Transform::from_xyz(-1.0, 0.4, -0.2),
                 mesh: meshes.add(Sphere::new(0.05).mesh().uv(7, 7)),
                 material: materials.add(StandardMaterial {
-                    base_color: css::GREEN.into(),
+                    base_color: css::LIME.into(),
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
`GREEN` in Bevy 0.13 was `0.0, 1.0, 0.0`, but Bevy 0.14's `css::GREEN` is `0.0, 0.5019608, 0.0` to match web color standards.

https://bevyengine.org/learn/migration-guides/0-13-to-0-14/#css-constants