### PR TITLE
Exposed IK Solver system set publicly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,14 @@ pub struct IkConstraint {
     pub enabled: bool,
 }
 
+/// System set used for calculating and updating inverse kinematics.
+/// Use for scheduling your systems before/after the IK Solver runs if necessary.
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IKSolverSystemSet;
+
 impl Plugin for InverseKinematicsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_systems(Update, solver::inverse_kinematics_system)
+        app.add_systems(Update, solver::inverse_kinematics_system.in_set(IKSolverSystemSet))
             .register_type::<IkConstraint>();
     }
 }


### PR DESCRIPTION
I didn't see anything about contributing in README / a Contributing.md so please let me know if contributions are unwelcome, really appreciate the crate and maintainers.

I have a use case where I need to run specific systems both before and after the IK solver systems (procedural animations -> ik solver -> rendering), but currently there's no way to do this. To deal with that, I made a system set containing the ik solver system, exposed publicly. This should be a non-breaking change, and allow use cases like mine, figured I'd open a PR back in case anyone else ran into the same use case / needs.

Once again, really appreciate the great open source work, thank you!